### PR TITLE
Add support for more delimiters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,11 @@ ifneq ($(NOLINT),1)
 	@echo ""
 endif
 ifeq ($(COVERAGE),1)
+	@echo "TESTING WITH COVERAGE... $@"
 	@go test -cover -coverprofile=$(GOPATH)/src/$@/c.out $@ -test.v
 	@go tool cover -html=$(GOPATH)/src/$@/c.out
 else
-	@echo "TESTING..."
+	@echo "TESTING... $@"
 	@go test $@ -test.v
 endif
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ go get github.com/Clever/csvlint/cmd/csvlint
 
 ### Options
 
-  * delimiter: the field delimiter to default with
-    * default: comma
-    * valid options: comma, tab
-    * if you want anything else, you're probably doing CSVs wrong
+_*NOTE*: The default settings validate that a CSV conforms to [RFC 4180](https://tools.ietf.org/html/rfc4180). By changing the settings, you can no longer strictly guarantee a CSV conforms to RFC 4180._
+
+  * delimiter: the field delimiter, can be any single unicode character
+    * default: "," (comma)
+    * valid options: "\t", "|", "ஃ", etc
+    * if you want multi-character delimiters, you're probably doing CSVs wrong
   * lazyquotes: allow a quote to appear in an unquoted field and a non-doubled quote to appear in a quoted field. _WARNING: your file may pass linting, but not parse in the way you would expect_
 
 ### Examples
@@ -44,7 +46,7 @@ $ csvlint mult_long_columns.csv
 Record #2 has error: wrong number of fields in line
 Record #4 has error: wrong number of fields in line
 
-$ csvlint --delimiter=tab mult_long_columns_tabs.csv
+$ csvlint --delimiter='\t' mult_long_columns_tabs.csv
 Record #2 has error: wrong number of fields in line
 Record #4 has error: wrong number of fields in line
 

--- a/cmd/csvlint/main.go
+++ b/cmd/csvlint/main.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"github.com/Clever/csvlint"
 	"os"
+	"strconv"
+	"unicode/utf8"
 )
 
 func printHelpAndExit(code int) {
@@ -13,7 +15,7 @@ func printHelpAndExit(code int) {
 }
 
 func main() {
-	delimiter := flag.String("delimiter", "comma", "field delimiter in the file. options: comma, tab, pipe, colon, semicolon")
+	delimiter := flag.String("delimiter", ",", "field delimiter in the file, for instance '\\t' or '|'")
 	lazyquotes := flag.Bool("lazyquotes", false, "try to parse improperly escaped quotes")
 	help := flag.Bool("help", false, "print help and exit")
 	flag.Parse()
@@ -22,22 +24,13 @@ func main() {
 		printHelpAndExit(0)
 	}
 
-	var comma rune
-	switch *delimiter {
-	case "comma":
-		comma = ','
-	case "tab":
-		comma = '\t'
-	case "pipe":
-		comma = '|'
-	case "colon":
-		comma = ':'
-	case "semicolon":
-		comma = ';'
-	default:
-		fmt.Printf("unrecognized delimiter '%s'\n\n", *delimiter)
+	converted_delimiter, err := strconv.Unquote(`'` + *delimiter + `'`)
+	if err != nil {
+		fmt.Printf("error unquoting delimiter '%s', note that only one-character delimiters are supported\n\n", *delimiter)
 		printHelpAndExit(1)
 	}
+	// don't need to check size since Unquote returns one-character string
+	comma, _ := utf8.DecodeRuneInString(converted_delimiter)
 
 	if len(flag.Args()) != 1 {
 		fmt.Println("csvlint accepts a single filepath as an argument\n")

--- a/cmd/csvlint/main.go
+++ b/cmd/csvlint/main.go
@@ -13,7 +13,7 @@ func printHelpAndExit(code int) {
 }
 
 func main() {
-	delimiter := flag.String("delimiter", "comma", "field delimiter in the file. options: comma, tab")
+	delimiter := flag.String("delimiter", "comma", "field delimiter in the file. options: comma, tab, pipe, colon, semicolon")
 	lazyquotes := flag.Bool("lazyquotes", false, "try to parse improperly escaped quotes")
 	help := flag.Bool("help", false, "print help and exit")
 	flag.Parse()
@@ -28,6 +28,12 @@ func main() {
 		comma = ','
 	case "tab":
 		comma = '\t'
+	case "pipe":
+		comma = '|'
+	case "colon":
+		comma = ':'
+	case "semicolon":
+		comma = ';'
 	default:
 		fmt.Printf("unrecognized delimiter '%s'\n\n", *delimiter)
 		printHelpAndExit(1)

--- a/cmd/csvlint/main.go
+++ b/cmd/csvlint/main.go
@@ -28,13 +28,13 @@ func main() {
 		fmt.Fprintln(os.Stderr, "Warning: not using defaults, may not validate CSV to RFC 4180")
 	}
 
-	converted_delimiter, err := strconv.Unquote(`'` + *delimiter + `'`)
+	convertedDelimiter, err := strconv.Unquote(`'` + *delimiter + `'`)
 	if err != nil {
 		fmt.Printf("error unquoting delimiter '%s', note that only one-character delimiters are supported\n\n", *delimiter)
 		printHelpAndExit(1)
 	}
 	// don't need to check size since Unquote returns one-character string
-	comma, _ := utf8.DecodeRuneInString(converted_delimiter)
+	comma, _ := utf8.DecodeRuneInString(convertedDelimiter)
 
 	if len(flag.Args()) != 1 {
 		fmt.Println("csvlint accepts a single filepath as an argument\n")

--- a/cmd/csvlint/main.go
+++ b/cmd/csvlint/main.go
@@ -24,6 +24,10 @@ func main() {
 		printHelpAndExit(0)
 	}
 
+	if flag.NFlag() > 0 {
+		fmt.Fprintln(os.Stderr, "Warning: not using defaults, may not validate CSV to RFC 4180")
+	}
+
 	converted_delimiter, err := strconv.Unquote(`'` + *delimiter + `'`)
 	if err != nil {
 		fmt.Printf("error unquoting delimiter '%s', note that only one-character delimiters are supported\n\n", *delimiter)

--- a/linter_test.go
+++ b/linter_test.go
@@ -15,6 +15,10 @@ var validationTable = []struct {
 	halted   bool
 }{
 	{file: "./test_data/perfect.csv", err: nil, invalids: []CSVError{}},
+	{file: "./test_data/perfect_tab.csv", err: nil, comma: '\t', invalids: []CSVError{}},
+	{file: "./test_data/perfect_pipe.csv", err: nil, comma: '|', invalids: []CSVError{}},
+	{file: "./test_data/perfect_colon.csv", err: nil, comma: ':', invalids: []CSVError{}},
+	{file: "./test_data/perfect_semicolon.csv", err: nil, comma: ';', invalids: []CSVError{}},
 	{file: "./test_data/one_long_column.csv", err: nil, invalids: []CSVError{{
 		Record: []string{"d", "e", "f", "g"},
 		err:    csv.ErrFieldCount,

--- a/test_data/perfect_colon.csv
+++ b/test_data/perfect_colon.csv
@@ -1,0 +1,3 @@
+field1:field2:field3
+a:b:c,notafield
+d:e:f

--- a/test_data/perfect_pipe.csv
+++ b/test_data/perfect_pipe.csv
@@ -1,0 +1,3 @@
+field1|field2|field3
+a|b|c,notafield
+d|e|f

--- a/test_data/perfect_semicolon.csv
+++ b/test_data/perfect_semicolon.csv
@@ -1,0 +1,3 @@
+field1;field2;field3
+a;b;c,notafield
+d;e;f

--- a/test_data/perfect_tab.csv
+++ b/test_data/perfect_tab.csv
@@ -1,0 +1,3 @@
+field1	field2	field3
+a	b	c,notafield
+d	e	f


### PR DESCRIPTION
This handles both #2 and #4. Only question I'd have is the stderr / stdout distinction for the warning message - I think sending to stderr is correct here, though.
I also think we should make a clean break with the past and not support 'comma' etc anymore (which requires a major version bump). I think few enough people use it and it's simple enough that it's not a tough change to update to the new interface.