### PR TITLE
fix linting in makefile by using subpackages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
-PKG = github.com/Clever/csvlint
-SUBPKGS = $(addprefix $(PKG)/, cmd/csvlint)
-PKGS = $(PKG) $(SUBPKGS)
+PKG := github.com/Clever/csvlint
+SUBPKGS := $(addprefix $(PKG)/, cmd/csvlint)
+PKGS := $(PKG) $(SUBPKGS)
 VERSION := $(shell cat VERSION)
 EXECUTABLE := csvlint
 BUILDS := \
@@ -11,19 +11,19 @@ BUILDS := \
 COMPRESSED_BUILDS := $(BUILDS:%=%.tar.gz)
 RELEASE_ARTIFACTS := $(COMPRESSED_BUILDS:build/%=release/%)
 
-.PHONY: test golint
-
-golint:
-	@go get github.com/golang/lint/golint
+.PHONY: clean run test $(PKGS)
 
 test: $(PKGS)
 
-$(PKGS): golint
+$(GOPATH)/bin/golint:
+	@go get github.com/golang/lint/golint
+
+$(PKGS): $(GOPATH)/bin/golint
 	@go get -d -t $@
 	@gofmt -w=true $(GOPATH)/src/$@/*.go
 ifneq ($(NOLINT),1)
 	@echo "LINTING..."
-	@PATH=$(PATH):$(GOPATH)/bin golint $(GOPATH)/src/$@/*.go
+	$(GOPATH)/bin/golint $(GOPATH)/src/$@/*.go
 	@echo ""
 endif
 ifeq ($(COVERAGE),1)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SHELL := /bin/bash
 PKG = github.com/Clever/csvlint
-PKGS = $(PKG)
+SUBPKGS = $(addprefix $(PKG)/, cmd/csvlint)
+PKGS = $(PKG) $(SUBPKGS)
 VERSION := $(shell cat VERSION)
 EXECUTABLE := csvlint
 BUILDS := \
@@ -19,10 +20,10 @@ test: $(PKGS)
 
 $(PKGS): golint
 	@go get -d -t $@
-	@gofmt -w=true $(GOPATH)/src/$@*/**.go
+	@gofmt -w=true $(GOPATH)/src/$@/*.go
 ifneq ($(NOLINT),1)
 	@echo "LINTING..."
-	@PATH=$(PATH):$(GOPATH)/bin golint $(GOPATH)/src/$@*/**.go
+	@PATH=$(PATH):$(GOPATH)/bin golint $(GOPATH)/src/$@/*.go
 	@echo ""
 endif
 ifeq ($(COVERAGE),1)


### PR DESCRIPTION
So this actually lints down to `cmd/csvlint` but there is a drawback - due to the way we test we get the following warning:
```
TESTING... github.com/Clever/csvlint/cmd/csvlint
?   	github.com/Clever/csvlint/cmd/csvlint	[no test files]
```
This warning doesn't fail the makefile or anything (error code is still 0), and I think I'm happier to have this warning than our code not be linted.
However if anyone has a different way of doing things to avoid this, I'd love to hear it!