### PR TITLE
[INFRA-3218] circleci migration cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,4 @@ jobs:
         name: Set up CircleCI artifacts directories
     - run: make install_deps
     - run: make test
-    - run: $HOME/ci-scripts/circleci/report-card $RC_DOCKER_USER $RC_DOCKER_PASS "$RC_DOCKER_EMAIL" $RC_GITHUB_TOKEN
-    - run:
-        command: |-
-          cd /tmp/ && wget https://bootstrap.pypa.io/get-pip.py && sudo python get-pip.py
-          sudo apt-get install python-dev
-          sudo pip install --upgrade awscli && aws --version
-          pip install --upgrade --user awscli
-        name: Install awscli for ECR publish
+    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then make release && $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN release; fi;


### PR DESCRIPTION
JIRA: [INFRA-3218](https://clever.atlassian.net/browse/INFRA-3218)

Improve on the initial CircleCI autotranslation:
- rm awscli install (unused, only needed for "docker publish")
- add back github release (accidentally removed) 
- rm report-card (deprecated)

