### PR TITLE
Microplane: add Github Action workflow for ci-notify

### DIFF
--- a/.github/workflows/notify-ci-status.yml
+++ b/.github/workflows/notify-ci-status.yml
@@ -1,0 +1,15 @@
+name: Notify CI status
+
+on: status
+
+jobs:
+  call-workflow:
+    if: >-
+      github.event.branches[0].name == 'master' &&
+      (github.event.state == 'error' || github.event.state == 'failure')    
+    uses: Clever/ci-scripts/.github/workflows/reusable-notify-ci-status.yml@master
+    secrets:
+      CIRCLE_CI_INTEGRATIONS_URL: ${{ secrets.CIRCLE_CI_INTEGRATIONS_URL }}
+      CIRCLE_CI_INTEGRATIONS_USERNAME: ${{ secrets.CIRCLE_CI_INTEGRATIONS_USERNAME }}
+      CIRCLE_CI_INTEGRATIONS_PASSWORD: ${{ secrets.CIRCLE_CI_INTEGRATIONS_PASSWORD }}
+      SLACK_BOT_TOKEN: ${{ secrets.DAPPLE_BOT_TOKEN }}


### PR DESCRIPTION
PR created via Microplane

This PR enables slack notifications via Dapple bot when CI fails on master, sent to the commit author, to ensure that eng action can be taken to ensure master doesn't remain in a failed state. This prevents issues such as a subsequent deploy deploying more new code than intended because it picks up a previous failed build's code.

If you have questions, please ask here or in #oncall-infra.
