### PR TITLE
Fix installation diective

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Standalone executables for multiple platforms are available via [Github Releases
 You can also compile from source:
 
 ```shell
-go install github.com/Clever/csvlint/cmd/csvlint
+go install github.com/Clever/csvlint/cmd/csvlint@latest
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Standalone executables for multiple platforms are available via [Github Releases
 You can also compile from source:
 
 ```shell
-go get github.com/Clever/csvlint/cmd/csvlint
+go install github.com/Clever/csvlint/cmd/csvlint
 ```
 
 ## Usage


### PR DESCRIPTION
When running `go get` as suggested by readme, the go cmd returns:
```
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecatio
```

This pr updates the documentation to the `go install` interface as suggested by golang cmd