### PR TITLE
[INFRANG-6876] Upgrade to go 1.24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/go/src/github.com/Clever/csvlint
     docker:
-    - image: cimg/go:1.21
+    - image: cimg/go:1.24
     environment:
       GOPRIVATE: github.com/Clever/*
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ RELEASE_ARTIFACTS := $(COMPRESSED_BUILDS:build/%=release/%)
 
 .PHONY: clean run test $(PKGS) vendor
 
-$(eval $(call golang-version-check,1.13))
+$(eval $(call golang-version-check,1.24))
 
 test: $(PKGS)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/csvlint
 
-go 1.21
+go 1.24
 
 require github.com/stretchr/testify v1.6.1
 


### PR DESCRIPTION
<!-- This template should be used as a living PR template for future go migrations -->

# JIRA
https://clever.atlassian.net/browse/INFRANG-6876

# About
This PR upgrades this repo to Go version 1.24. See the [release notes](https://tip.golang.org/doc/go1.24) for full details.

It performs the following changes:
1. Upgrade the module to 1.24.
2. Upgrade the golang.mk file to the latest version.
3. Replaces any `tools.go` file with the new go.mod tools directive.
4. Updates any circle CI build images to 1.24.
5. Updates the go version check in the makefile.
6. Updates any debian docker images to a version with a glibc compatible with the CI build image.



#### New Go Vet Check
Go vet in 1.24 introduces a new check which catches non-constant format strings in calls to printf functions. This has a tendency to find bugs in existing code, however the fix is pretty strait forward should your CI begin to fail. You can see more details in the official issue https://github.com/golang/go/issues/60529. If your CI fails because of this, you may add an extra commit resolving the issue, then merge. The microplane script attempts to resolve as many of these cases as possible automatically.

# Testing
Go version upgrades have historically been extremely stable. The only exception has been incompatible glibc versions which have been tested for in workers before merging. All standard CI testing is also performed before merging.

# Problems Upgrading?
Checkout this [google doc](https://docs.google.com/document/d/1ctg3eT8zkKHXqsf7CCUBB77ERmEVMsyZoYAIxXm19hs/edit?usp=sharing) for knowledge sharing any problems you encounter during upgrades!
