### PR TITLE
Use the go install syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Standalone executables for multiple platforms are available via [Github Releases
 You can also compile from source:
 
 ```shell
-go get github.com/Clever/csvlint/cmd/csvlint
+go install github.com/Clever/csvlint/cmd/csvlint@latest
 ```
 
 ## Usage


### PR DESCRIPTION
Apparently, "go get" is deprecated.

This command worked for me, and I have csvlint working on OSX after mucking about with my PATH for a bit. 

Thanks for the great work!! 